### PR TITLE
Add roleDefinitions and roleAssignments to ResourceQuota

### DIFF
--- a/sdk/data_cosmos/src/resource_quota.rs
+++ b/sdk/data_cosmos/src/resource_quota.rs
@@ -87,7 +87,7 @@ pub(crate) fn resource_quotas_from_str(full_string: &str) -> Result<Vec<Resource
         } else if let Some(stripped) = token.strip_prefix(ROLE_ASSIGNMENTS) {
             v.push(ResourceQuota::RoleAssignments(parseu64(stripped)?));
         } else {
-            return Err(Error::with_message(ErrorKind::DataConversion, || {
+            log::warn!("{}", Error::with_message(ErrorKind::DataConversion, || {
                 format!(
                     "resource quota has an unrecognized part - part: \"{}\" full string: \"{}\"",
                     token, full_string

--- a/sdk/data_cosmos/src/resource_quota.rs
+++ b/sdk/data_cosmos/src/resource_quota.rs
@@ -21,6 +21,8 @@ pub enum ResourceQuota {
     ClientEncryptionKeys(u64),
     InteropUsers(u64),
     AuthPolicyElements(u64),
+    RoleDefinitions(u64),
+    RoleAssignments(u64),
 }
 
 const DATABASES: &str = "databases=";
@@ -37,6 +39,8 @@ const FUNCTIONS: &str = "functions=";
 const CLIENT_ENCRYPTION_KEYS: &str = "clientEncryptionKeys=";
 const INTEROP_USERS: &str = "interopUsers=";
 const AUTH_POLICY_ELEMENTS: &str = "authPolicyElements=";
+const ROLE_DEFINITIONS: &str = "roleDefinitions=";
+const ROLE_ASSIGNMENTS: &str = "roleAssignments=";
 
 /// Parse a collection of [`ResourceQuota`] from a string
 pub(crate) fn resource_quotas_from_str(full_string: &str) -> Result<Vec<ResourceQuota>> {
@@ -78,6 +82,10 @@ pub(crate) fn resource_quotas_from_str(full_string: &str) -> Result<Vec<Resource
             v.push(ResourceQuota::InteropUsers(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(AUTH_POLICY_ELEMENTS) {
             v.push(ResourceQuota::AuthPolicyElements(parseu64(stripped)?));
+        } else if let Some(stripped) = token.strip_prefix(ROLE_DEFINITIONS) {
+            v.push(ResourceQuota::RoleDefinitions(parseu64(stripped)?));
+        } else if let Some(stripped) = token.strip_prefix(ROLE_ASSIGNMENTS) {
+            v.push(ResourceQuota::RoleAssignments(parseu64(stripped)?));
         } else {
             return Err(Error::with_message(ErrorKind::DataConversion, || {
                 format!(
@@ -125,7 +133,7 @@ mod tests {
                 ResourceQuota::Collections(5000),
                 ResourceQuota::Users(500000),
                 ResourceQuota::Permissions(2000000),
-                ResourceQuota::ClientEncryptionKeys(13)
+                ResourceQuota::ClientEncryptionKeys(13),
             ]
         );
 
@@ -140,7 +148,7 @@ mod tests {
             vec![
                 ResourceQuota::DocumentSize(0),
                 ResourceQuota::DocumentsSize(2),
-                ResourceQuota::CollectionSize(3)
+                ResourceQuota::CollectionSize(3),
             ]
         );
 
@@ -160,6 +168,17 @@ mod tests {
         assert_eq!(
             resource_quota,
             vec![ResourceQuota::ClientEncryptionKeys(13)]
+        );
+
+        let resource_quota =
+            resource_quotas_from_str("roleDefinitions=100;roleAssignments=2000;").unwrap();
+
+        assert_eq!(
+            resource_quota,
+            vec![
+                ResourceQuota::RoleDefinitions(100),
+                ResourceQuota::RoleAssignments(2000),
+            ]
         );
     }
 }

--- a/test/transactions/database_operations/0_response.json
+++ b/test/transactions/database_operations/0_response.json
@@ -19,7 +19,7 @@
     "x-ms-number-of-read-regions": "0",
     "x-ms-request-charge": "2",
     "x-ms-request-duration-ms": "0.328",
-    "x-ms-resource-quota": "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;",
+    "x-ms-resource-quota": "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;",
     "x-ms-resource-usage": "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;",
     "x-ms-schemaversion": "1.13",
     "x-ms-serviceversion": "version=2.14.0.0",

--- a/test/transactions/database_operations/2_response.json
+++ b/test/transactions/database_operations/2_response.json
@@ -19,7 +19,7 @@
     "x-ms-number-of-read-regions": "0",
     "x-ms-request-charge": "2",
     "x-ms-request-duration-ms": "0.392",
-    "x-ms-resource-quota": "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;",
+    "x-ms-resource-quota": "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;",
     "x-ms-resource-usage": "databases=2;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;",
     "x-ms-schemaversion": "1.13",
     "x-ms-serviceversion": "version=2.14.0.0",

--- a/test/transactions/database_operations/5_response.json
+++ b/test/transactions/database_operations/5_response.json
@@ -19,7 +19,7 @@
     "x-ms-number-of-read-regions": "0",
     "x-ms-request-charge": "2",
     "x-ms-request-duration-ms": "0.465",
-    "x-ms-resource-quota": "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;",
+    "x-ms-resource-quota": "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;",
     "x-ms-resource-usage": "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;",
     "x-ms-schemaversion": "1.13",
     "x-ms-serviceversion": "version=2.14.0.0",


### PR DESCRIPTION
To reproduce the issue without this change, first add `roleDefinitions` and `roleAssignments` to the response json files and then:

```
$ TESTING_MODE=REPLAY cargo test database_operations --features=mock_transport_framework
<elided...>
running 1 test
test database_operations ... FAILED

failures:

---- database_operations stdout ----
Error: Error { context: Message { kind: DataConversion, message: "resource quota has an unrecognized part - part: \"roleDefinitions=100\" full string: \"databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;\"" } }
thread 'database_operations' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/test/src/lib.rs:187:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    database_operations

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s

error: test failed, to rerun pass '-p azure_data_cosmos --test database_operations'
```

https://github.com/spd-mfa/azure-sdk-for-rust/blob/main/docs/mock_transport.md